### PR TITLE
Add Module level docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,23 @@
+//! Client-side library to interact with Versioned Storage Service (VSS).
+//!
+//! VSS is an open-source project designed to offer a server-side cloud storage solution specifically
+//! tailored for non-custodial Lightning supporting mobile wallets. Its primary objective is to
+//! simplify the development process for Lightning wallets by providing a secure means to store
+//! and manage the essential state required for Lightning Network (LN) operations.
+//!
+//! Learn more [here](https://github.com/lightningdevkit/vss-server/blob/main/README.md).
+
 #![deny(rustdoc::broken_intra_doc_links)]
 #![deny(rustdoc::private_intra_doc_links)]
 
+use crate::client::VssClient;
+use crate::error::VssError;
+
+/// Implements a thin-client ([`VssClient`]) to access a hosted instance of Versioned Storage Service (VSS).
 pub mod client;
+
+/// Implements the error type ([`VssError`]) returned on interacting with [`VssClient`]
 pub mod error;
+
+/// Contains request/response types generated from the API definition of VSS.
 pub mod types;


### PR DESCRIPTION
Note that crate level doc is mostly a placeholder, more details regarding usage to be documented pre-release. 