### PR TITLE
Make `genproto` a `cfg` flag instead of a feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,13 +15,10 @@ build = "build.rs"
 prost = "0.11.6"
 reqwest = { version = "0.11.13", features = ["rustls-tls"] }
 
-[build-dependencies]
+[target.'cfg(genproto)'.build-dependencies]
 prost-build = { version = "0.11.3" }
 reqwest =  { version = "0.11.13", features = ["blocking"] }
 
 [dev-dependencies]
 mockito = "0.31.1"
 tokio = { version = "1.22.0", features = ["macros"]}
-
-[features]
-genproto = []

--- a/build.rs
+++ b/build.rs
@@ -1,17 +1,17 @@
-#[cfg(feature = "genproto")]
+#[cfg(genproto)]
 extern crate prost_build;
-#[cfg(feature = "genproto")]
+#[cfg(genproto)]
 use std::{env, fs, fs::File, path::Path};
 
 /// To generate updated proto objects:
 /// 1. Place `vss.proto` file in `src/proto/`
-/// 2. run `cargo build --features=genproto`
+/// 2. run `RUSTFLAGS="--cfg genproto" cargo build`
 fn main() {
-	#[cfg(feature = "genproto")]
+	#[cfg(genproto)]
 	generate_protos();
 }
 
-#[cfg(feature = "genproto")]
+#[cfg(genproto)]
 fn generate_protos() {
 	download_file(
 				"https://raw.githubusercontent.com/lightningdevkit/vss-server/cb1159c3b1835c66a857b25b114f15d18d2a4297/app/src/main/proto/vss.proto",
@@ -23,7 +23,7 @@ fn generate_protos() {
 	fs::copy(from_path, "src/types.rs").unwrap();
 }
 
-#[cfg(feature = "genproto")]
+#[cfg(genproto)]
 fn download_file(url: &str, save_to: &str) -> Result<(), Box<dyn std::error::Error>> {
 	let mut response = reqwest::blocking::get(url)?;
 	fs::create_dir_all(Path::new(save_to).parent().unwrap())?;


### PR DESCRIPTION
Previously, the build dependencies of the `genproto` feature weren't optional, so they were built even when not required, leading to some breakage downstream (see https://github.com/lightningdevkit/ldk-node/issues/197 and https://github.com/lightningdevkit/ldk-node/pull/207).

However, `genproto` arguably generally shouldn't be a user-facing feature of this crate, but is rather better hidden behind a `cfg` flag. Here, we do exactly that, also fixing the issue mentioned above.

(cc @G8XSU)