### PR TITLE
Add a `VssClient::from_client` constructor

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -28,6 +28,11 @@ impl VssClient {
 		Self { base_url: String::from(base_url), client }
 	}
 
+	/// Returns the underlying base URL.
+	pub fn base_url(&self) -> &str {
+		&self.base_url
+	}
+
 	/// Fetches a value against a given `key` in `request`.
 	/// Makes a service call to the `GetObject` endpoint of the VSS server.
 	/// For API contract/usage, refer to docs for [`GetObjectRequest`] and [`GetObjectResponse`].


### PR DESCRIPTION
We add a `VssClient::from_client` constructor that allows users to hand in a preconfigured `reqwest::Client`, which is particularily useful to allow them to set default headers, e.g., for header-based authentication.