### PR TITLE
Drop `default-features` for `reqwest`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,13 +13,13 @@ build = "build.rs"
 
 [dependencies]
 prost = "0.11.6"
-reqwest = { version = "0.11.13", features = ["rustls-tls"] }
+reqwest = { version = "0.11.13", default-features = false, features = ["rustls-tls"] }
 tokio = { version = "1", default-features = false, features = ["time"] }
 rand = "0.8.5"
 
 [target.'cfg(genproto)'.build-dependencies]
 prost-build = { version = "0.11.3" }
-reqwest =  { version = "0.11.13", features = ["blocking"] }
+reqwest =  { version = "0.11.13", default-features = false, features = ["rustls-tls", "blocking"] }
 
 [dev-dependencies]
 mockito = "0.31.1"


### PR DESCRIPTION
While we previously enabled `rustls` support for `reqwest`, we forgot to disable `default-features`, meaning we'd also build with `reqwest`'s `default-tls` feature, which is huge and can lead for issues on downstream projects:

`default-tls = ["hyper-tls", "native-tls-crate", "__tls", "tokio-native-tls"]`

While longer-term we could consider adding features to allow users to enable and disable specific TLS stacks, we here therefore disable `default-features` for now.